### PR TITLE
monitoring: update Sojourner GPU exporter port to 9835

### DIFF
--- a/kubernetes/orion/apps/monitoring/prometheus-application.yaml
+++ b/kubernetes/orion/apps/monitoring/prometheus-application.yaml
@@ -104,7 +104,7 @@ spec:
                 - targets: ['docker.bou1der.net:9100']
             - job_name: 'Sojourner'
               static_configs:
-                - targets: ['ml01.bou1der.net:9202', 'ml01.bou1der.net:9100']
+                - targets: ['ml01.bou1der.net:9835', 'ml01.bou1der.net:9100']
               metrics_path: /metrics
               params:
                 module: [default]


### PR DESCRIPTION
Switch nvidia_gpu_exporter scrape target from 9202 to 9835 to match
the default port used by ghcr.io/utkuozdemir/nvidia_gpu_exporter.
