### PR TITLE
fix(grafana): correct malformed HTTPRoute rules structure

### DIFF
--- a/kubernetes/orion/manifests/monitoring/grafana/grafana-httproute.yaml
+++ b/kubernetes/orion/manifests/monitoring/grafana/grafana-httproute.yaml
@@ -10,8 +10,8 @@ spec:
   hostnames:
   - "grafana.bou1der.net"
   rules:
-  - path:
-    - host:
+  - matches:
+    - path:
         type: PathPrefix
         value: /
     filters:

--- a/kubernetes/orion/manifests/monitoring/grafana/grafana-httproute.yaml
+++ b/kubernetes/orion/manifests/monitoring/grafana/grafana-httproute.yaml
@@ -21,5 +21,8 @@ spec:
           type: ReplacePrefixMatch
           replacePrefixMatch: /
     backendRefs:
-    - name: grafana  # service name set by helm chart
+    - group: ''
+      kind: Service
+      name: grafana  # service name set by helm chart
       port: 80
+      weight: 1


### PR DESCRIPTION
Replace invalid `path`/`host` keys at rule level with proper `matches`
block, matching the gateway.networking.k8s.io/v1 HTTPRoute spec and
consistent with other HTTPRoutes in the repo.

https://claude.ai/code/session_01FrnJrZ1UEcwweh1ms3426S